### PR TITLE
README overhaul, say "sidecore" in usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,13 @@ Using flattened Docker images from <https://github.com/u-root/sidecore-images>,
 
 Building on top of [`cpu`](https://github.com/u-root/cpu), **sidecore** merely
 requires your IoT system to run a small daemon in order to use it as a resource.
+
+## Building
+
+**NOTE**: Go version 1.20 is required as a minimum.
+
+Run `go build ./cmds/sidecore` to build the command.
+
+## Usage
+
+After building the command, run `./sidecore -h` for help.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 # sidecore
 
 ![Sidecore](art/sidecorelogo.png)
-sidecore lets you run IoT systems, using flattened docker images from githu.bcom/u-root/sidecore-images, as easily as you run a shell script
+
+Using flattened Docker images from <https://github.com/u-root/sidecore-images>,
+**sidecore** lets you run IoT systems as easily as you run a shell script.
+
+## How it works
+
+Building on top of [`cpu`](https://github.com/u-root/cpu), **sidecore** merely
+requires your IoT system to run a small daemon in order to use it as a resource.

--- a/cmds/sidecore/main.go
+++ b/cmds/sidecore/main.go
@@ -318,7 +318,7 @@ SIDECORE_IMAGES -- where the flattened cpio images are kept -- default ~/sidecor
 SIDECORE_KEYFILE -- key file, e.g. ~/.ssh/cpu_rsa -- default "", since it can be looked up in ~/.ssh/config for non-mDNS cases
 SIDECORE_HOSTKEYFILE -- host key file, it can be empty. -- default ""
 `)
-	log.Fatalf("%v:Usage: cpu [options] host [shell command]:\n%v", err, b.String())
+	log.Fatalf("%v:Usage: sidecore [options] host [shell command]:\n%v", err, b.String())
 }
 
 // Windows breaks all the rules, so we generate a


### PR DESCRIPTION
- README: rephrase, fix link, add reference to cpu
- cmds/sidecore: print `sidecore` in usage instead of `cpu`
